### PR TITLE
Fixed alignment issue in tables under education(#233)

### DIFF
--- a/layouts/partials/sections/education.html
+++ b/layouts/partials/sections/education.html
@@ -59,7 +59,7 @@
                                 {{ $hideScale  := .takenCourses.hideScale }}
                                 <table>
                                     <thead>
-                                        <th>{{ i18n "course_name"}}</th>
+                                        <th class="course-name-header">{{ i18n "course_name"}}</th>
                                         {{ if not $hideScale  }}<th>{{ i18n "total_credit"}}</th>{{ end }}
                                         <th>{{ i18n "obtained_credit"}}</th>
                                     </thead>

--- a/static/css/sections/education.css
+++ b/static/css/sections/education.css
@@ -102,7 +102,9 @@
   border: none;
   color: #212529;
 }
-
+.education-section .taken-courses th.course-name-header{
+  width: 50%;
+}
 .education-section .taken-courses .hidden-course {
   display: none;
   transition: all 1s ease-out;


### PR DESCRIPTION
### Issue
This pull request fixes #233 

### Description
In the `education.html` file I added the following `<th class="course-name-header">{{ i18n "course_name"}}</th>`  to the header course name column with a style of `width 50%` in education.css file.


### Test Evidence
[screen-capture-education](https://user-images.githubusercontent.com/40003718/136926275-8f454554-5341-4ee7-9aac-1aca50c31bd1.PNG)