### PR TITLE
Fix badge display when name is too long

### DIFF
--- a/static/css/sections/about.css
+++ b/static/css/sections/about.css
@@ -87,11 +87,14 @@
   background: #3c4858;
   font-size: 1rem;
   color: #f9fafc;
-  line-height: 135px;
+  line-height: initial;
   text-align: center;
   position: absolute;
   top: 5%;
   left: 5%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .circular-progress.blue .circular-progress-bar {


### PR DESCRIPTION
### Issue
Fixes #443 

### Description
Used flex display with vertical and horizontal alignments and set line-height to initial.

### Test Evidence
* Made a symbolic link to the updated code as the theme to wip hugo site.
* Visually checked the bug has been solved.