### PR TITLE
Disables analytics on localhost

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -2,10 +2,7 @@
 {{ with site.Params.features.analytics }}
     {{ if or .enable .enabled }}
         {{ with .services }}
-        {{ $url := absURL "" }}
-          {{ $pUrl := urls.Parse $url }}
-          {{ $hName := $pUrl.Host }}
-          {{ if and $hName ( ne $hName "localhost") }}
+        {{ if and hugo.IsProduction (or .enable .enabled)}}
             <!-- Google Analytics -->
             {{ with .google }}
                 {{ partial "google_analytics.html" . }}


### PR DESCRIPTION
### Issue
#1126

### Description

Prevents analytics services from loading when the site is accessed via localhost. This change ensures that development environments do not generate unnecessary or misleading analytics data.

### Test Evidence