### PR TITLE
Feat/blog show date

### DIFF
--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -310,6 +310,12 @@ params:
     readingTime:
       enable: false
 
+    # Enable post date/time display on cards and single pages. Default is "true".
+    showDate:
+      # on_single: false
+      # on_cards: false
+
+
     # Number of posts to show to each page. Default is "12"
     pagination:
       maxPostsPerPage: 12

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -306,9 +306,9 @@ params:
     copyCodeButton:
       enable: true
 
-    # Enable reading time support in post cards and in post pages
+    # Enable reading time support in post cards and in post pages. Default is "true".
     readingTime:
-      enable: false
+      # enable: false
 
     # Enable post date/time display on cards and single pages. Default is "true".
     showDate:

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -312,8 +312,8 @@ params:
 
     # Enable post date/time display on cards and single pages. Default is "true".
     showDate:
-      # on_single: false
-      # on_cards: false
+      # singlePage: false
+      # postCards: false
 
 
     # Number of posts to show to each page. Default is "12"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -42,7 +42,7 @@
         <div class="author-profile ms-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
+          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime.enable | default true }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
             {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>
         {{ else }}
@@ -55,7 +55,7 @@
 
         {{ if not (site.Params.features.blog.showAuthor | default true) }}
         <div class="author-profile ms-auto align-self-lg-center">
-          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
+          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime.enable | default true }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
             {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>
         {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -42,7 +42,7 @@
         <div class="author-profile ms-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} |
+          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
             {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>
         {{ else }}
@@ -55,7 +55,7 @@
 
         {{ if not (site.Params.features.blog.showAuthor | default true) }}
         <div class="author-profile ms-auto align-self-lg-center">
-          <p class="text-muted">{{ .Page.Date | time.Format ":date_full" }}{{ if site.Params.features.readingTime }} |
+          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
             {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>
         {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -38,12 +38,16 @@
 
       <!--Content Start-->
       <div class="page-content">
+        {{ $showDate := site.Params.features.showDate.singlePage | default true }}
+        {{ $showReadingTime := site.Params.features.readingTime.enable | default true }}
         {{ if site.Params.features.blog.showAuthor | default true }}
         <div class="author-profile ms-auto align-self-lg-center">
           <img class="rounded-circle" src='{{ partial "helpers/get-author-image.html" . }}' alt="Author Image">
           <h5 class="author-name">{{ partial "helpers/get-author-name.html" . }}</h5>
-          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime.enable | default true }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
-            {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
+          <p class="text-muted">
+            {{ if $showDate }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}
+            {{ if and $showDate $showReadingTime }} | {{ end }}
+            {{ if $showReadingTime }}{{ .ReadingTime }}{{i18n "minute" .ReadingTime }}{{ end }}</p>
         </div>
         {{ else }}
         <div style="margin-bottom: 80px;"></div>
@@ -55,8 +59,11 @@
 
         {{ if not (site.Params.features.blog.showAuthor | default true) }}
         <div class="author-profile ms-auto align-self-lg-center">
-          <p class="text-muted">{{ if site.Params.features.showDate.on_single | default true }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}{{ if site.Params.features.readingTime.enable | default true }}{{ if site.Params.features.showDate.on_single | default true }} |{{ end }}
-            {{ .ReadingTime }} {{i18n "minute" .ReadingTime }}{{ end }}</p>
+          <p class="text-muted">
+            {{ if $showDate }}{{ .Page.Date | time.Format ":date_full" }}{{ end }}
+            {{ if and $showDate $showReadingTime }} | {{ end }}
+            {{ if $showReadingTime }}{{ .ReadingTime }}{{i18n "minute" .ReadingTime }}{{ end }}
+          </p>
         </div>
         {{ end }}
 

--- a/layouts/partials/cards/post.html
+++ b/layouts/partials/cards/post.html
@@ -18,9 +18,13 @@
       {{ end }}
     </div>
     <div class="card-footer">
+      {{ $showDate := site.Params.features.showDate.postCards | default true }}
+      {{ $showReadingTime := site.Params.features.readingTime.enable | default true }}
       <span class="float-start">
-        {{ if site.Params.features.showDate.on_cards | default true }}{{ .Date | time.Format ":date_full" }}{{ end }}
-        {{ if site.Params.features.readingTime.enable | default true }}{{ if site.Params.features.showDate.on_cards | default true }} | {{ end }}{{.ReadingTime}} {{ i18n "minute" .ReadingTime }} {{ end }}</span>
+        {{ if $showDate }}{{ .Date | time.Format ":date_full" }}{{ end }}
+        {{ if and $showDate $showReadingTime }} | {{ end }}
+        {{ if $showReadingTime }}{{.ReadingTime}} {{ i18n "minute" .ReadingTime }}{{ end }}
+      </span>
       <a href="{{ .RelPermalink | relLangURL }}" class="float-end btn btn-outline-info btn-sm">{{ i18n "read" }}</a>
     </div>
   </div>

--- a/layouts/partials/cards/post.html
+++ b/layouts/partials/cards/post.html
@@ -20,7 +20,7 @@
     <div class="card-footer">
       <span class="float-start">
         {{ if site.Params.features.showDate.on_cards | default true }}{{ .Date | time.Format ":date_full" }}{{ end }}
-        {{ if site.Params.features.readingTime }}{{ if site.Params.features.showDate.on_cards | default true }} | {{ end }}{{.ReadingTime}} {{ i18n "minute" .ReadingTime }} {{ end }}</span>
+        {{ if site.Params.features.readingTime.enable | default true }}{{ if site.Params.features.showDate.on_cards | default true }} | {{ end }}{{.ReadingTime}} {{ i18n "minute" .ReadingTime }} {{ end }}</span>
       <a href="{{ .RelPermalink | relLangURL }}" class="float-end btn btn-outline-info btn-sm">{{ i18n "read" }}</a>
     </div>
   </div>

--- a/layouts/partials/cards/post.html
+++ b/layouts/partials/cards/post.html
@@ -19,8 +19,8 @@
     </div>
     <div class="card-footer">
       <span class="float-start">
-        {{ .Date | time.Format ":date_full" }}
-        {{ if site.Params.features.readingTime }} | {{.ReadingTime}} {{ i18n "minute" .ReadingTime }} {{ end }}</span>
+        {{ if site.Params.features.showDate.on_cards | default true }}{{ .Date | time.Format ":date_full" }}{{ end }}
+        {{ if site.Params.features.readingTime }}{{ if site.Params.features.showDate.on_cards | default true }} | {{ end }}{{.ReadingTime}} {{ i18n "minute" .ReadingTime }} {{ end }}</span>
       <a href="{{ .RelPermalink | relLangURL }}" class="float-end btn btn-outline-info btn-sm">{{ i18n "read" }}</a>
     </div>
   </div>


### PR DESCRIPTION
This PR includes two related fixes in blog post metadata rendering.

1. **Configurable post date visibility (single page + cards)**
Added support for toggling date display via:
- `site.Params.features.showDate.on_single`
- `site.Params.features.showDate.on_cards`
Both options are treated as enabled by default.
This fixes the issue where a date was always rendered in some cases, resulting in an invalid-looking fallback output such as _"Monday, January 1, 1"_ when no proper post date was set.

2. **Fix reading time toggle and default behavior**
Corrected the reading time condition to use the proper config path (`features.readingTime.enable`) in both:
- `layouts/_default/single.html`
- `layouts/partials/cards/post.html`
Reading time is now controlled correctly and defaults to **enabled** (`true`) when not explicitly set.

Both changes are backward-compatible and make metadata rendering consistent across single post pages and post cards.

<img width="1618" height="771" alt="Снимок экрана 2026-05-15 021917" src="https://github.com/user-attachments/assets/07a9cb86-6061-454a-89a3-5a92834972b3" />
<img width="1612" height="862" alt="Снимок экрана 2026-05-15 022011" src="https://github.com/user-attachments/assets/5835433a-534b-485d-8f3c-006a6562639a" />
<img width="1612" height="832" alt="Снимок экрана 2026-05-15 022040" src="https://github.com/user-attachments/assets/75c76ae3-ffdb-4841-a39b-b2340bfd1f7c" />
<img width="1615" height="1001" alt="Снимок экрана 2026-05-15 022106" src="https://github.com/user-attachments/assets/72fbf434-10bc-4451-b4c4-261aff72a1df" />
<img width="681" height="622" alt="Снимок экрана 2026-05-15 022148" src="https://github.com/user-attachments/assets/e771d3b6-aaf1-40e2-b4f8-5204efcdf930" />
<img width="685" height="657" alt="Снимок экрана 2026-05-15 022218" src="https://github.com/user-attachments/assets/ff5b08b0-b3d1-4ccb-a736-f989b5a84348" />
Both changes are backward-compatible and make metadata rendering consistent across single post pages and post cards.

