### PR TITLE
Fix: leading spaces in Go template string literals cause `%20` in generated URLs

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,12 +10,12 @@
 <section class="sidebar-section" id="sidebar-section">
   <div class="sidebar-holder">
     <div class="sidebar" id="sidebar">
-      <form class="mx-auto" method="get" action="{{ " search" | relLangURL }}">
-        <input type="text" name="keyword" value="" placeholder="{{ i18n " search" }}" data-search="" id="search-box" />
+      <form class="mx-auto" method="get" action="{{ "search" | relLangURL }}">
+        <input type="text" name="keyword" value="" placeholder="{{ i18n "search" }}" data-search="" id="search-box" />
       </form>
       <div class="sidebar-tree">
         <ul class="tree" id="tree">
-          <li id="list-heading"><a href="{{ " /posts/" | relLangURL }}" data-filter="all">{{ i18n "posts" }}</a></li>
+          <li id="list-heading"><a href="{{ "/posts/" | relLangURL }}" data-filter="all">{{ i18n "posts" }}</a></li>
           <div class="subtree">
             {{ partial "navigators/sidebar.html" (dict "menuName" "sidebar" "menuItems" site.Menus.sidebar "ctx" .) }}
           </div>
@@ -154,14 +154,14 @@
           {{ end }}
           <div class="col-md-6 btn-improve-page">
             {{ if ( eq site.Params.GitForge "gitlab" ) }}
-            <a href="{{ site.Params.GitRepo }}/-/edit/{{ .Scratch.Get " GitBranch" }}/content/{{ .File.Path }}"
-              title="{{ i18n " improve_this_page" }}" target="_blank" rel="noopener">
+            <a href="{{ site.Params.GitRepo }}/-/edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}"
+              title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
               {{ else if ( eq site.Params.GitForge "gitea" ) }}
-              <a href="{{ site.Params.GitRepo }}/_edit/{{ .Scratch.Get " GitBranch" }}/content/{{ .File.Path }}"
-                title="{{ i18n " improve_this_page" }}" target="_blank" rel="noopener">
+              <a href="{{ site.Params.GitRepo }}/_edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}"
+                title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
                 {{ else }} <!--- Make Github-style the default -->
-                <a href="{{ site.Params.GitRepo }}/edit/{{ .Scratch.Get " GitBranch" }}/content/{{ .File.Path }}"
-                  title="{{ i18n " improve_this_page" }}" target="_blank" rel="noopener">
+                <a href="{{ site.Params.GitRepo }}/edit/{{ .Scratch.Get "GitBranch" }}/content/{{ .File.Path }}"
+                  title="{{ i18n "improve_this_page" }}" target="_blank" rel="noopener">
                   {{ end }}
                   <i class="fas fa-code-branch"></i>
                   {{ i18n "improve_this_page" }}

--- a/layouts/partials/sections/home.html
+++ b/layouts/partials/sections/home.html
@@ -218,7 +218,7 @@
     {{ if .section.id }}
     {{ $sectionID = .section.id }}
     {{ end }}
-    <a href="#{{ $sectionID }}" class="arrow-center" aria-label="{{ i18n " read" }} {{ i18n "more" }} - {{ $name }}"> <i
+    <a href="#{{ $sectionID }}" class="arrow-center" aria-label="{{ i18n "read" }} {{ i18n "more" }} - {{ $name }}"> <i
         class="arrow bounce fa fa-chevron-down"></i></a>
     {{ end }}
     {{ end }}


### PR DESCRIPTION
### Problem

When navigating to any single post page (e.g. `/posts/my-post/`), the sidebar rendered broken links:

- Search form action: `/%20search` instead of `/search`
- Search input placeholder: empty instead of the translated string
- Portfolio link: `/%20/posts/` instead of `/posts/`

The same issue affected the `aria-label` on the home section scroll arrow and the "Improve this page" button links (when `GitRepo` is configured).

The bug was reproducible on both `localhost` and GitHub Pages across all languages.

### Root cause

Several Go template string literals contained a leading space inside the double-quote delimiters. Because these strings are embedded inside HTML attributes that also use double quotes, the outer quote closes the HTML attribute early, and the Go template engine receives the remainder as a separate string with a leading space:

```html
<!-- broken -->
action="{{ " search" | relLangURL }}"
```

Hugo's `relLangURL` faithfully URL-encodes the leading space as `%20`. 
For `i18n` and `.Scratch.Get` the key with a leading space does not exist, so they return an empty string.

### Fix

Removed the leading space from all affected string literals:

| File | Template expression (before → after) |
|---|---|
| `layouts/_default/single.html` | `" search"` → `"search"` |
| `layouts/_default/single.html` | `" /posts/"` → `"/posts/"` |
| `layouts/_default/single.html` | `" GitBranch"` → `"GitBranch"` |
| `layouts/_default/single.html` | `" improve_this_page"` → `"improve_this_page"` |
| `layouts/partials/sections/home.html` | `" read"` → `"read"` |

### Testing

Built the example site with `hugo` and verified:

- Sidebar search `action` attribute renders `/search` (or `/bn/search` for
  non-default languages) on all single post pages
- Search `placeholder` attribute contains the translated string
- Portfolio heading link renders `/posts/` correctly
- Home section scroll arrow `aria-label` contains the translated "read more"
  text

Before was:
```html
    <div class="sidebar" id="sidebar">
      <form class="mx-auto" method="get" action="/%20search">
        <input type="text" name="keyword" value="" placeholder="" data-search="" id="search-box" />
      </form>
      <div class="sidebar-tree">
        <ul class="tree" id="tree">
          <li id="list-heading"><a href="/%20/posts/" data-filter="all">Posts</a></li>
```

After this fix:
```html
    <div class="sidebar" id="sidebar">
      <form class="mx-auto" method="get" action="/search">
        <input type="text" name="keyword" value="" placeholder="Search" data-search="" id="search-box">
      </form>
      <div class="sidebar-tree">
        <ul class="tree" id="tree">
          <li id="list-heading"><a href="/posts/" data-filter="all">Posts</a></li>
```