### PR TITLE
Feature: configurable link target and clickable tags on project cards

### DIFF
--- a/exampleSite/data/bn/sections/projects.yaml
+++ b/exampleSite/data/bn/sections/projects.yaml
@@ -47,6 +47,17 @@ projects:
   summary: Lorem ipsum dolor sit amet consectetur adipisicing elit. Sapiente eius reprehenderit animi suscipit autem eligendi esse amet aliquid error eum. Accusantium distinctio soluta aliquid quas placeat modi suscipit eligendi nisi.
   tags: ["academic","iot"]
 
+- name: Rich Content
+  url: "posts/category/sub-category/rich-content/"
+  # Optional: control how project links open. Allowed values: "blank" (default) or "self".
+  # "blank" opens links in a new tab, "self" opens them in the current tab.
+  target: self
+  # Optional: when true, project tags become links to the corresponding /tags/<tag>/ pages.
+  # Defaults to false (tags are rendered as non-clickable badges).
+  linkTags: true
+  summary: Links on this post will open in the current tab. And Tags are clickable links in the post tags.
+  tags: ["মার্কডাউন","কন্টেন্ট সাজানো","বহুভাষিক"]
+  
 - name: Nocode
   logo: /images/sections/projects/no-code.png
   role: Nothing

--- a/exampleSite/data/en/sections/projects.yaml
+++ b/exampleSite/data/en/sections/projects.yaml
@@ -46,6 +46,17 @@ projects:
   summary: Lorem ipsum dolor sit amet consectetur adipisicing elit. Sapiente eius reprehenderit animi suscipit autem eligendi esse amet aliquid error eum. Accusantium distinctio soluta aliquid quas placeat modi suscipit eligendi nisi.
   tags: ["academic","iot"]
 
+- name: Rich Content
+  url: "/posts/category/sub-category/rich-content/"
+  # Optional: control how project links open. Allowed values: "blank" (default) or "self".
+  # "blank" opens links in a new tab, "self" opens them in the current tab.
+  target: self
+  # Optional: when true, project tags become links to the corresponding /tags/<tag>/ pages.
+  # Defaults to false (tags are rendered as non-clickable badges).
+  linkTags: true
+  summary: Links on this post will open in the current tab. And Tags are clickable links in the post tags.
+  tags: ["Multi-lingual","Content Organization","Markdown"]
+
 - name: Nocode
   logo: /images/sections/projects/no-code.png
   role: Nothing

--- a/layouts/partials/cards/project.html
+++ b/layouts/partials/cards/project.html
@@ -1,8 +1,11 @@
 <div class="col-sm-12 col-md-6 col-lg-4 p-2 filtr-item" data-category='all, {{ delimit  .tags ","}}'>
   <div class="card mt-1">
     <div class="card">
+      {{- $target := .target | default "blank" -}}
+      {{- $targetAttr := "_blank" -}}
+      {{- if eq $target "self" -}}{{- $targetAttr = "_self" -}}{{- end -}}
       <a href="{{ if .repo }}{{ .repo }}{{ else if .url }}{{ .url }}{{ else }}javascript:void(0){{ end }}" {{ if or
-        .repo .url }}target="_blank" rel="noopener" {{ end }}>
+        .repo .url }}target="{{ $targetAttr }}" rel="noopener" {{ end }}>
         {{ if .image }}
         <div class="card-head">
           {{ $imageImage:= resources.Get .image}}
@@ -58,9 +61,17 @@
           {{ if .tags }}
           <div class="project-tags-holder">
             {{ range $index,$tag:= .tags }}
+            {{ if $.linkTags }}
+            <a href="{{ printf "/tags/%s/" (urlize $tag) | relLangURL }}">
+              <span class="btn badge btn-info">
+                {{ $tag }}
+              </span>
+            </a>
+            {{ else }}
             <span class="btn badge btn-info">
               {{ $tag }}
             </span>
+            {{ end }}
             {{ end }}
           </div>
           {{ end }}
@@ -71,7 +82,7 @@
               data-show-count="true" aria-label="Star {{ .name }}">{{ i18n "project_star" }}</a>
             {{ else if .url }}
             <span>
-              <a class="btn btn-outline-info btn-sm" href="{{ .url }}" target="#">{{ i18n "project_details" }}</a>
+              <a class="btn btn-outline-info btn-sm" href="{{ .url }}" target="{{ $targetAttr }}" rel="noopener">{{ i18n "project_details" }}</a>
             </span>
             {{ end }}
           </div>


### PR DESCRIPTION
### Motivation

Currently all links on project cards (title and "Details" button) unconditionally open in a new browser tab (`target="_blank"`). There is no way to make them open in the current tab — useful for internal links to posts inside the same site.

Project tags are rendered as plain non-interactive badges. There is no built-in way to turn them into links to the Hugo taxonomy pages.

### New per-project options

Both options are set per project entry in the section data file (`data/<lang>/sections/projects.yaml`):

**`target`** — controls where the title link and the "Details" button open.

| Value | Behaviour |
|---|---|
| `blank` *(default)* | Opens in a new tab (`target="_blank"`) |
| `self` | Opens in the current tab (`target="_self"`) |

The GitHub star button (`github-button`) is not affected and always opens in a new tab (behaviour is managed by the GitHub Buttons script).

**`linkTags`** — controls whether tags are rendered as clickable links.

| Value | Behaviour |
|---|---|
| `false` *(default)* | Tags are plain `<span>` badges — no change from current behaviour |
| `true` | Each tag becomes an `<a>` pointing to `/tags/<tag>/` (respects `relLangURL` for multilingual sites) |

### Usage example

```yaml
projects:
- name: My internal post
  url: "/posts/my-post/"
  target: self        # open in current tab
  linkTags: true      # make tags clickable
  summary: This card links to an internal post and has clickable tags.
  tags: ["hugo", "theme"]

- name: External project
  url: "https://example.com"
  # target defaults to "blank" — opens in a new tab
  summary: This card opens an external URL in a new tab (default behaviour).
  tags: ["open-source"]
```

### Changed files

- `layouts/partials/cards/project.html` — reads `.target` and `.linkTags` from project data; computes `$targetAttr` once and applies it to both the title link and the "Details" button; wraps each tag in `<a>` when `linkTags` is true
- `exampleSite/data/en/sections/projects.yaml` — updated demo entry with `target` and `linkTags` to showcase the new options
- `exampleSite/data/bn/sections/projects.yaml` — same update for the Bengali locale

### Screenshots
<img width="1182" height="567" alt="Снимок экрана 2026-05-18 192209" src="https://github.com/user-attachments/assets/63ae2688-a3c6-4c95-a611-1fd413d6b710" />
<img width="1300" height="826" alt="Снимок экрана 2026-05-18 192327" src="https://github.com/user-attachments/assets/089ab85c-a1bb-4116-bff6-e5eeddc7fbc4" />
