### PR TITLE
fix: support external URLs and page bundle images in project cards

### DIFF
--- a/exampleSite/data/en/sections/projects.yaml
+++ b/exampleSite/data/en/sections/projects.yaml
@@ -48,6 +48,7 @@ projects:
 
 - name: Rich Content
   url: "/posts/category/sub-category/rich-content/"
+  image: "https://toha-preview.hugo-themes.com/posts/category/sub-category/rich-content/images/forest.jpg"
   # Optional: control how project links open. Allowed values: "blank" (default) or "self".
   # "blank" opens links in a new tab, "self" opens them in the current tab.
   target: self

--- a/layouts/partials/cards/project.html
+++ b/layouts/partials/cards/project.html
@@ -8,6 +8,9 @@
         .repo .url }}target="{{ $targetAttr }}" rel="noopener" {{ end }}>
         {{ if .image }}
         <div class="card-head">
+          {{ if or (hasPrefix .image "http://") (hasPrefix .image "https://") }}
+          <img class="card-img-top" src="{{ .image }}" alt="{{ .name }}" loading="lazy" />
+          {{ else }}
           {{ $imageImage:= resources.Get .image}}
           {{ if $imageImage }}
           {{/* svg don't support "Fit" operation */}}
@@ -17,6 +20,9 @@
           <img class="card-img-top" src="{{ $imageImage.RelPermalink }}" alt="{{ .name }}" loading="lazy" {{ if ne
             $imageImage.MediaType.SubType "svg" }}width="{{ $imageImage.Width }}" height="{{ $imageImage.Height }}" {{
             end }} />
+          {{ else }}
+          <img class="card-img-top" src="{{ .image }}" alt="{{ .name }}" loading="lazy" />
+          {{ end }}
           {{ end }}
         </div>
         {{ end }}
@@ -31,6 +37,9 @@
 
               {{ else }}
 
+              {{ if or (hasPrefix .logo "http://") (hasPrefix .logo "https://") }}
+              <img class="card-img-xs" src="{{ .logo }}" alt="{{ .name }}" />
+              {{ else }}
               {{ $logoImage:= resources.Get .logo}}
               {{ if $logoImage }}
               {{/* svg don't support "Fit" operation */}}
@@ -40,6 +49,9 @@
               <img class="card-img-xs" src="{{ $logoImage.RelPermalink }}" alt="{{ .name }}" {{ if ne
                 $logoImage.MediaType.SubType "svg" }}width="{{ $logoImage.Width }}" height="{{ $logoImage.Height }}" {{
                 end }} />
+              {{ else }}
+              <img class="card-img-xs" src="{{ .logo }}" alt="{{ .name }}" />
+              {{ end }}
               {{ end }}
               {{ end }}
 


### PR DESCRIPTION
## Summary

Project card template failed when `image` or `logo` pointed to:
1. **External URLs** (`https://...`) — `resources.Get` tried to resolve them as local filesystem paths, causing a build error.
2. **Page bundle resources** (e.g. `/posts/.../images/forest.jpg`) — `resources.Get` only resolves files in `assets/`, so the image was silently skipped.

## Changes

`layouts/partials/cards/project.html`:
- Added `hasPrefix` check for `http://` / `https://` — external URLs are rendered directly as `<img src="...">` without `resources.Get`.
- Added fallback: if `resources.Get` returns `nil` for a local path, render the path directly (supports page bundle images).
- Same logic applied to both `image` and `logo` fields.
- Add pic with external URL to exampleSite

## Backward Compatibility

Existing asset-based images continue to work through Hugo Pipes (Fit, SVG detection). No breaking changes to data schema.
<img width="1919" height="946" alt="2026-06-23-173037" src="https://github.com/user-attachments/assets/003cf55f-d155-4666-8df5-580c4abfde20" />
