### PR TITLE
Fix conditional for enabling analytics

### DIFF
--- a/layouts/partials/analytics.html
+++ b/layouts/partials/analytics.html
@@ -1,8 +1,7 @@
 <!-- Add Analytics if enabled in configuration -->
 {{ with site.Params.features.analytics }}
-    {{ if or .enable .enabled }}
+    {{ if and hugo.IsProduction (or .enable .enabled) }}
         {{ with .services }}
-        {{ if and hugo.IsProduction (or .enable .enabled)}}
             <!-- Google Analytics -->
             {{ with .google }}
                 {{ partial "google_analytics.html" . }}
@@ -51,7 +50,6 @@
             {{ with .posthog }}
             <!-- PostHog analytics loaded via JavaScript module -->
             {{ end }}
-          {{ end }}
         {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
### Issue
<!--- Insert a link to the associated github issue here. -->
Fixes https://github.com/hugo-themes/toha/issues/1178

### Description
Fix nested `enabled` conditional in analytics params.
<!-- Insert details about what the changes being proposed are. -->

### Test Evidence
The bugged variant forced you to configure params as:
```
params:
  features:
    analytics:
      enabled: true
      services:
        enabled: true
        ...
```

Instead of the intended
```
params:
  features:
    analytics:
      enabled: true
      services:
        ...
```
<!-- Provide screenshot evidence and/or testing steps to validate the proposed changes. -->