### PR TITLE
fix: position the 404 message against the illustration

### DIFF
--- a/assets/styles/layouts/404.scss
+++ b/assets/styles/layouts/404.scss
@@ -3,7 +3,13 @@ body.kind-404 {
     display: none;
   }
 
+  .container {
+    text-align: center;
+  }
+
   .notFound {
+    position: relative;
+    display: inline-block;
     padding-top: 5rem;
     text-align: center;
     padding-bottom: 8rem;
@@ -16,48 +22,33 @@ body.kind-404 {
       font-style: italic;
     }
 
+    // The message is painted on the wall in the illustration, so it has to be
+    // positioned against the illustration rather than against the page.
     .message {
       position: absolute;
-      max-width: 20rem;
-      top: 40%;
-      left: 30%;
-    }
-  }
-
-  @include media('<=very-large') {
-    .notFound .message {
-      top: 50%;
+      top: 26%;
       left: 25%;
+      width: 40%;
     }
   }
 
-  @include media('<=large') {
-    .notFound .message {
-      top: 46%;
-      left: 25%;
-    }
-  }
-
+  // No room to fit the message on the wall, so put it below the illustration.
   @include media('<=medium') {
     .notFound {
-      img {
-        height: 400px;
-      }
-      .message {
-        top: 20rem;
-        left: 4rem;
-      }
-    }
-  }
+      display: block;
 
-  @include media('<=small') {
-    .notFound {
       img {
-        height: 250px;
+        height: auto;
+        max-width: 100%;
+        margin-left: auto;
+        margin-right: auto;
       }
+
       .message {
-        top: 20rem;
-        left: 2rem;
+        position: static;
+        width: auto;
+        max-width: 20rem;
+        margin: 2rem auto 0;
       }
     }
   }


### PR DESCRIPTION
## Problem

On the 404 page the message overlaps the illustration, and the illustration is not centered.

Both are visible on the demo site — <https://toha-preview.hugo-themes.com/no-such-page/> at a 1400px wide viewport puts "404" across the cat's legs.

There are two separate causes.

**1. The message is positioned against the page, not the illustration.**

`.message` is `position: absolute` with `top: 40%; left: 30%`, but `.notFound` is not a positioned ancestor, so those percentages resolve against the initial containing block. The message is placed at a fraction of the *page*, which has nothing to do with where the illustration ends up, so it drifts onto the drawing as the viewport changes. The per-breakpoint `top`/`left` overrides tune this for particular sizes but cannot fix the underlying reference.

**2. The illustration is never centered.**

`components/images.scss` sets `img { display: block }` globally, so the `text-align: center` on `.notFound` has no effect on it and the drawing sits flush against the left edge of the container. This is also what makes the first problem worse: the message is placed relative to the page while the illustration is pinned left, so the two are laid out independently.

There is a third, smaller issue below the breakpoints: the illustration has a fixed `height` while the global `img { max-width: 100% }` clamps its width, so on a narrow viewport it renders horizontally squashed rather than scaled down.

## Fix

- Make `.notFound` an `inline-block` positioning context so it shrinks to the illustration. `top`/`left` on `.message` then resolve against the illustration itself and hold at any width, which also removes the need for the per-breakpoint offsets.
- Center `.notFound` with `text-align: center` on the container, which centers the illustration with it.
- Below the medium breakpoint there is not enough room to put the message on the wall, so stack it under the illustration, and let the illustration scale proportionally (`height: auto` + `max-width: 100%`) instead of being squashed.

## Testing

Built a site with this branch and checked the 404 page at 1400, 1100, 1000, 900, 760 and 390 CSS px. The message stays on the painted area down to the medium breakpoint and is stacked below the illustration under it; the illustration is centered and keeps its aspect ratio at every size.

One note on reproducing this: headless Chrome will not lay a page out below roughly 500px wide, so `--window-size=390` still renders at ~500px and only crops the screenshot. The narrow-width checks above were done by loading the page in a 390px `<iframe>`, which gets a real 390px layout viewport.